### PR TITLE
add Ant logger for JSch

### DIFF
--- a/src/main/java/se/steinhauer/tools/ant/JschLoggerForAnt.java
+++ b/src/main/java/se/steinhauer/tools/ant/JschLoggerForAnt.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014, george thomas
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE CRYPTIX FOUNDATION LIMITED AND
+ * CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE CRYPTIX FOUNDATION LIMITED OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package se.steinhauer.tools.ant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+
+import com.jcraft.jsch.Logger;
+
+/**
+ * An implementation of JSch's {@link Logger} that writes to Ant's logger.
+ *
+ * @author george thomas
+ * @since 2014-10-05
+ */
+public class JschLoggerForAnt implements Logger {
+
+    @SuppressWarnings("serial")
+    private static final Map<Integer, Integer> levelMapper = new HashMap<Integer, Integer>() {{
+        put(Logger.DEBUG, Project.MSG_VERBOSE);
+        /*
+         * unfortunately, because JSch uses the Logger.INFO level to log all
+         * SSH communication, we map it to Project.MSG_VERBOSE to eliminate
+         * noise from the output
+         */
+        put(Logger.INFO, Project.MSG_VERBOSE);
+        put(Logger.WARN, Project.MSG_WARN);
+        put(Logger.ERROR, Project.MSG_ERR);
+        put(Logger.FATAL, Project.MSG_ERR);
+    }};
+
+    private Task task = null;
+
+    public JschLoggerForAnt(Task task) {
+        this.task = task;
+    }
+
+    /**
+     * @see com.jcraft.jsch.Logger#isEnabled(int)
+     */
+    @Override
+    public boolean isEnabled(int level) {
+        return true;
+    }
+
+    /**
+     * @see com.jcraft.jsch.Logger#log(int, java.lang.String)
+     */
+    @Override
+    public void log(int level, String message) {
+        task.getProject().log(message, levelMapper.get(level));
+    }
+}

--- a/src/main/java/se/steinhauer/tools/ant/git/GitRemoteTask.java
+++ b/src/main/java/se/steinhauer/tools/ant/git/GitRemoteTask.java
@@ -35,6 +35,7 @@ import org.eclipse.jgit.transport.OperationResult;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.StringUtils;
+import se.steinhauer.tools.ant.JschLoggerForAnt;
 import se.steinhauer.tools.jgit.transport.JschKeyfileConfigSessionFactory;
 import se.steinhauer.tools.jgit.transport.SshKeyfileCredentialsProvider;
 
@@ -150,7 +151,7 @@ public abstract class GitRemoteTask extends Task {
      */
     protected void initKeyfileJschConfig() {
         JschKeyfileConfigSessionFactory jschConfigSessionFactory = new JschKeyfileConfigSessionFactory(keyfilePath);
-
+        jschConfigSessionFactory.setLogger(new JschLoggerForAnt(this));
         SshSessionFactory.setInstance(jschConfigSessionFactory);
     }
 

--- a/src/main/java/se/steinhauer/tools/jgit/transport/JschKeyfileConfigSessionFactory.java
+++ b/src/main/java/se/steinhauer/tools/jgit/transport/JschKeyfileConfigSessionFactory.java
@@ -31,6 +31,7 @@ package se.steinhauer.tools.jgit.transport;
 
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Logger;
 import com.jcraft.jsch.Session;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
 import org.eclipse.jgit.transport.OpenSshConfig;
@@ -122,5 +123,9 @@ public class JschKeyfileConfigSessionFactory extends JschConfigSessionFactory {
 
     public void setStrictHostKeyChecking(boolean strictHostKeyChecking) {
         this.strictHostKeyChecking = strictHostKeyChecking;
+    }
+
+    public void setLogger(Logger logger) {
+        JSch.setLogger(logger);
     }
 }


### PR DESCRIPTION
JSch uses its own logger through the interface com.jcraft.jsch.Logger
and offers a static utility method to override its implementation of
this interface with another one.

Wiring up an Ant logger allows us to get finer logger from JSch using
the -verbose or -debug options when running Ant.
